### PR TITLE
Add Support for Hubspace Lightbulbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Not all features for all products are implemented. Please see the functions belo
 | --- | --- |
 | [Universal Smart Wi-Fi 4-Speed Ceiling Fan](https://www.homedepot.com/p/Hampton-Bay-Universal-Smart-Wi-Fi-4-Speed-Ceiling-Fan-White-Remote-Control-For-Use-Only-With-AC-Motor-Fans-Powered-by-Hubspace-76278/315169181?) | <ul><li>Light on/off</li><li>Fan on/off</li><li>Light brightness</li><li>Fan speed</li></ul> |
 | [Defiant Smart Plug](https://www.homedepot.com/p/Defiant-15-Amp-120-Volt-Smart-Wi-Fi-Bluetooth-Plug-with-1-Outlet-Powered-by-Hubspace-HPPA11AWB/315636834) | <ul><li>Power on/off</li></ul> |
+| [ BR30 Color CCT Light](https://www.homedepot.com/p/EcoSmart-65-Watt-Equivalent-Smart-BR30-Color-Changing-CEC-LED-Light-Bulb-with-Voice-Control-1-Bulb-Powered-by-Hubspace-11BR3065WRGBWH1/318411936) | <ul><li>Power on/off</li><li>Light brightness</li><li>Light color</li><li>Light temperature</li></ul> |
+| [A19 Color CCT Light](https://www.homedepot.com/p/EcoSmart-60-Watt-Equivalent-Smart-A19-Color-Changing-CEC-LED-Light-Bulb-with-Voice-Control-1-Bulb-Powered-by-Hubspace-11A19060WRGBWH1/318411935) | <ul><li>Power on/off</li><li>Light brightness</li><li>Light color</li><li>Light temperature</li></ul> |
 
 # Development
 There is no official documentation for Hubspace products. Under the hood they use Afero cloud as the mechanism that controls the products. Any functionality here is gained by experimenting with various functions of the devices. Afero provides simple explanation of [their APIs](https://developer.afero.io/API-DeviceEndpoints), however, this is in no way comprehensive.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Not all features for all products are implemented. Please see the functions belo
 | [Defiant Smart Plug](https://www.homedepot.com/p/Defiant-15-Amp-120-Volt-Smart-Wi-Fi-Bluetooth-Plug-with-1-Outlet-Powered-by-Hubspace-HPPA11AWB/315636834) | <ul><li>Power on/off</li></ul> |
 | [ BR30 Color CCT Light](https://www.homedepot.com/p/EcoSmart-65-Watt-Equivalent-Smart-BR30-Color-Changing-CEC-LED-Light-Bulb-with-Voice-Control-1-Bulb-Powered-by-Hubspace-11BR3065WRGBWH1/318411936) | <ul><li>Power on/off</li><li>Light brightness</li><li>Light color</li><li>Light temperature</li></ul> |
 | [A19 Color CCT Light](https://www.homedepot.com/p/EcoSmart-60-Watt-Equivalent-Smart-A19-Color-Changing-CEC-LED-Light-Bulb-with-Voice-Control-1-Bulb-Powered-by-Hubspace-11A19060WRGBWH1/318411935) | <ul><li>Power on/off</li><li>Light brightness</li><li>Light color</li><li>Light temperature</li></ul> |
+| [A21 Color CCT Light](https://www.homedepot.com/p/EcoSmart-100-Watt-Equivalent-Smart-A21-Color-Changing-CEC-LED-Light-Bulb-with-Voice-Control-1-Bulb-Powered-by-Hubspace-11A21100WRGBWH1/318411937) | <ul><li>Power on/off</li><li>Light brightness</li><li>Light color</li><li>Light temperature</li></ul> |
 
 # Development
 There is no official documentation for Hubspace products. Under the hood they use Afero cloud as the mechanism that controls the products. Any functionality here is gained by experimenting with various functions of the devices. Afero provides simple explanation of [their APIs](https://developer.afero.io/API-DeviceEndpoints), however, this is in no way comprehensive.

--- a/config.schema.json
+++ b/config.schema.json
@@ -24,6 +24,13 @@
         "required": true,
         "description": "Your Hubspace password",
         "placeholder": "Password"
+      },
+      "dualColorSpace": {
+        "title": "Dual Color Space",
+        "type": "boolean",
+        "required": false,
+        "description": "Have RGB Lights enumerate a second light which supports the temperature color space.",
+        "placeholder": "false"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "hubspace"
   ],
   "dependencies": {
-    "axios": "^1.3.2"
+    "axios": "^1.3.2",
+    "color-convert": "^2.0.1"
   },
   "devDependencies": {
     "@types/node": "^18.13.0",

--- a/src/accessories/device-accessory-factory.ts
+++ b/src/accessories/device-accessory-factory.ts
@@ -7,6 +7,8 @@ import { HubspaceAccessory } from './hubspace-accessory';
 import { LightAccessory } from './light-accessory';
 import { OutletAccessory } from './outlet-accessory';
 
+import { DeviceFunction } from '../models/device-functions';
+
 /**
  * Creates {@link HubspaceAccessory} for a specific {@link DeviceType}
  * @param device Device information
@@ -18,7 +20,11 @@ import { OutletAccessory } from './outlet-accessory';
 export function createAccessoryForDevice(device: Device, platform: HubspacePlatform, accessory: PlatformAccessory): HubspaceAccessory{
     switch(device.type){
         case DeviceType.Light:
-            return new LightAccessory(platform, accessory);
+            if (device.name.endsWith(' Temperature')) {
+                return new LightAccessory(platform, accessory, false);
+            } else {
+                return new LightAccessory(platform, accessory, true);
+            }
         case DeviceType.Fan:
             return new FanAccessory(platform, accessory);
         case DeviceType.Outlet:

--- a/src/accessories/fan-accessory.ts
+++ b/src/accessories/fan-accessory.ts
@@ -2,7 +2,7 @@ import { CharacteristicValue, PlatformAccessory } from 'homebridge';
 import { HubspacePlatform } from '../platform';
 import { HubspaceAccessory } from './hubspace-accessory';
 import { isNullOrUndefined } from '../utils';
-import { DeviceFunction } from '../models/device-functions';
+import { DeviceFunction, getDeviceFunctionDef } from '../models/device-functions';
 
 /**
  * Fan accessory for Hubspace platform
@@ -39,12 +39,14 @@ export class FanAccessory extends HubspaceAccessory{
     }
 
     private async setActive(value: CharacteristicValue): Promise<void>{
-        this.deviceService.setValue(this.device.deviceId, DeviceFunction.FanPower, value);
+        const func = getDeviceFunctionDef(this.device.functions, DeviceFunction.FanPower);
+        await this.deviceService.setValue(this.device.deviceId, func.values[0].deviceValues[0].key, value);
     }
 
     private async getActive(): Promise<CharacteristicValue>{
         // Try to get the value
-        const value = await this.deviceService.getValue(this.device.deviceId, DeviceFunction.FanPower);
+        const func = getDeviceFunctionDef(this.device.functions, DeviceFunction.FanPower);
+        const value = await this.deviceService.getValue(this.device.deviceId, func.values[0].deviceValues[0].key);
 
         // If the value is not defined then show 'Not Responding'
         if(isNullOrUndefined(value)){
@@ -57,7 +59,8 @@ export class FanAccessory extends HubspaceAccessory{
 
     private async getRotationSpeed(): Promise<CharacteristicValue>{
         // Try to get the value
-        const value = await this.deviceService.getValue(this.device.deviceId, DeviceFunction.FanSpeed);
+        const func = getDeviceFunctionDef(this.device.functions, DeviceFunction.FanSpeed);
+        const value = await this.deviceService.getValue(this.device.deviceId, func.values[0].deviceValues[0].key);
 
         // If the value is not defined then show 'Not Responding'
         if(isNullOrUndefined(value)){
@@ -69,7 +72,8 @@ export class FanAccessory extends HubspaceAccessory{
     }
 
     private async setRotationSpeed(value: CharacteristicValue): Promise<void>{
-        await this.deviceService.setValue(this.device.deviceId, DeviceFunction.FanSpeed, value);
+        const func = getDeviceFunctionDef(this.device.functions, DeviceFunction.FanSpeed);
+        await this.deviceService.setValue(this.device.deviceId, func.values[0].deviceValues[0].key, value);
     }
 
 }

--- a/src/accessories/hubspace-accessory.ts
+++ b/src/accessories/hubspace-accessory.ts
@@ -59,7 +59,7 @@ export abstract class HubspaceAccessory{
      * @returns True if function is supported by the device otherwise false
      */
     protected supportsFunction(deviceFunction: DeviceFunction): boolean{
-        return this.device.functions.some(fc => fc === deviceFunction);
+        return this.device.functions.some(fc => fc.functionClass === deviceFunction);
     }
 
 }

--- a/src/accessories/light-accessory.ts
+++ b/src/accessories/light-accessory.ts
@@ -1,7 +1,7 @@
 import { CharacteristicValue, PlatformAccessory } from 'homebridge';
 import { HubspacePlatform } from '../platform';
 import { HubspaceAccessory } from './hubspace-accessory';
-import { isNullOrUndefined } from '../utils';
+import { isNullOrUndefined, normalizeValue } from '../utils';
 import { DeviceFunction } from '../models/device-functions';
 
 /**
@@ -19,6 +19,13 @@ export class LightAccessory extends HubspaceAccessory{
 
         this.configurePower();
         this.configureBrightness();
+
+        // * If [Color Temperature] characteristic is included in the `Light Bulb`, `Hue` and `Saturation` must not be included as optional
+        // * characteristics in `Light Bulb`. This characteristic must not be used for lamps which support color.
+        //if(this.configureColor())
+        {
+            this.configureTemperature();
+        }
     }
 
     private configurePower(): void{
@@ -33,6 +40,27 @@ export class LightAccessory extends HubspaceAccessory{
         this.service.getCharacteristic(this.platform.Characteristic.Brightness)
             .onGet(this.getBrightness.bind(this))
             .onSet(this.setBrightness.bind(this));
+    }
+
+    private configureTemperature(): void{
+        if(!this.supportsFunction(DeviceFunction.LightTemperature)) return;
+
+        this.service.getCharacteristic(this.platform.Characteristic.ColorTemperature)
+            .onGet(this.getTemperature.bind(this))
+            .onSet(this.setTemperature.bind(this));
+    }
+
+    private configureColor(): boolean{
+        if(!this.supportsFunction(DeviceFunction.LightColor)) return false;
+
+        this.service.getCharacteristic(this.platform.Characteristic.Hue)
+            .onGet(this.getHue.bind(this))
+            .onSet(this.setHue.bind(this));
+        this.service.getCharacteristic(this.platform.Characteristic.Saturation)
+            .onGet(this.getSaturation.bind(this))
+            .onSet(this.setSaturation.bind(this));
+
+        return true;
     }
 
     private async getOn(): Promise<CharacteristicValue>{
@@ -55,6 +83,7 @@ export class LightAccessory extends HubspaceAccessory{
     private async getBrightness(): Promise<CharacteristicValue>{
         // Try to get the value
         const value = await this.deviceService.getValueAsInteger(this.device.deviceId, DeviceFunction.Brightness);
+        this.log.debug(`${this.device.name}: Received ${value} from Hubspace Brightness`);
 
         // If the value is not defined then show 'Not Responding'
         if(isNullOrUndefined(value) || value === -1){
@@ -66,7 +95,68 @@ export class LightAccessory extends HubspaceAccessory{
     }
 
     private async setBrightness(value: CharacteristicValue): Promise<void>{
+        this.log.debug(`${this.device.name}: Received ${value} from Homekit Brightness`);
         this.deviceService.setValue(this.device.deviceId, DeviceFunction.Brightness, value);
     }
 
+    private async getTemperature(): Promise<CharacteristicValue>{
+        // Try to get the value
+        const kelvin = await this.deviceService.getValueAsInteger(this.device.deviceId, DeviceFunction.LightTemperature);
+        const value = normalizeValue(kelvin as number, 6500, 2200, 140, 500, 1);
+        this.log.debug(`${this.device.name}: Received ${kelvin} from Hubspace Color Temperature, sending ${value} to Homebridge`);
+
+        // If the value is not defined then show 'Not Responding'
+        if(isNullOrUndefined(value) || value === -1){
+            throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+        }
+
+        // Otherwise return the value
+        return value!;
+    }
+
+    private async setTemperature(value: CharacteristicValue): Promise<void>{
+        // HomeKit Sends values with a min of 140 and a max of 500 with a step of 1
+        // and Hubbridge expects values of a different scale such as 2200K to 6500K
+        // with a step of 100
+        const kelvin = normalizeValue(value as number, 140, 500, 6500, 2200, 100);
+        this.log.debug(`${this.device.name}: Received ${value} from Homekit Color Temperature, sending ${kelvin}K to Hubridge`);
+        this.deviceService.setValue(this.device.deviceId, DeviceFunction.LightTemperature, kelvin);
+    }
+
+    private async getHue(): Promise<CharacteristicValue>{
+        // Try to get the value
+        const value = await this.deviceService.getValueAsInteger(this.device.deviceId, DeviceFunction.LightColor);
+
+        // If the value is not defined then show 'Not Responding'
+        if(isNullOrUndefined(value) || value === -1){
+            throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+        }
+
+        // Otherwise return the value
+        return value!;
+    }
+
+    private async setHue(value: CharacteristicValue): Promise<void>{
+
+
+        // this.deviceService.setValue(this.device.deviceId, DeviceFunction.LightColor, value);
+    }
+
+    private async getSaturation(): Promise<CharacteristicValue>{
+        // // Try to get the value
+        // const value = await this.deviceService.getValueAsInteger(this.device.deviceId, DeviceFunction.LightColor);
+
+        // // If the value is not defined then show 'Not Responding'
+        // if(isNullOrUndefined(value) || value === -1){
+        //     throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+        // }
+
+        const value = 0;
+        // Otherwise return the value
+        return value!;
+    }
+
+    private async setSaturation(value: CharacteristicValue): Promise<void>{
+        this.deviceService.setValue(this.device.deviceId, DeviceFunction.LightColor, value);
+    }
 }

--- a/src/accessories/light-accessory.ts
+++ b/src/accessories/light-accessory.ts
@@ -91,10 +91,10 @@ export class LightAccessory extends HubspaceAccessory{
 
         // TODO: understand what undefined would look like for this??
         // If the value is not defined then show 'Not Responding'
-        // if(isNullOrUndefined(value) || value === -1){
-        //     this.log.error(`${this.device.name}: Received Comm Failure for get Brightness`);
-        //     throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
-        // }
+        if(isNullOrUndefined(value) || value === -1){
+            this.log.error(`${this.device.name}: Received Comm Failure for get Brightness`);
+            throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+        }
 
         this.log.info(`${this.device.name}: Received ${value} from Hubspace Brightness`);
 
@@ -114,10 +114,10 @@ export class LightAccessory extends HubspaceAccessory{
 
         // TODO: understand what undefined would look like for this??
         // If the value is not defined then show 'Not Responding'
-        // if(isNullOrUndefined(kelvin) || kelvin === -1){
-        //     this.log.error(`${this.device.name}: Received Comm Failure for get Temperature`);
-        //     throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
-        // }
+        if(isNullOrUndefined(kelvin) || kelvin === -1){
+            this.log.error(`${this.device.name}: Received Comm Failure for get Temperature`);
+            throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+        }
 
         const value = normalizeValue(kelvin as number, 6500, 2200, 140, 500, 1);
         this.log.info(`${this.device.name}: Received ${kelvin} from Hubspace Color Temperature, sending ${value} to Homebridge`);
@@ -149,7 +149,8 @@ export class LightAccessory extends HubspaceAccessory{
 
         const [r, g, b] = hexToRgb(rgb as string);
         const [h, s, v] = rgbToHsv(r, g, b);
-        this.log.info(`${this.device.name}: Received ${rgb} from Hubspace Color RGB, sending ${h} to Homebridge for Hue`);
+        this.log.info(
+            `${this.device.name}: Received ${rgb} from Hubspace Color RGB, sending ${h} to Homebridge for Hue`);
 
         // Otherwise return the value
         return (h as CharacteristicValue)!;
@@ -160,21 +161,22 @@ export class LightAccessory extends HubspaceAccessory{
 
         const rgb = await this.deviceService.getValue(this.device.deviceId, DeviceFunction.LightColor);
 
-        // TODO: understand what undefined would look like for this??
         // If the value is not defined then show 'Not Responding'
-        // if(isNullOrUndefined(rgb) || rgb === -1)
-        {
-
-            // Preform a read, modify, write of RGB with Hue
-            let [r, g, b] = hexToRgb(rgb as string);
-            const [h, s, v] = rgbToHsv(r, g, b);
-            [r, g, b] = hsvToRgb(value as number, s, v);
-            const hexRgb = rgbToHex(r, g, b);
-
-            this.log.info(`${this.device.name}: Received ${value} from Homekit Hue, sending ${hexRgb} from ${rgb} to Hubspace Color RGB`);
-
-            this.deviceService.setValue(this.device.deviceId, DeviceFunction.LightColor, hexRgb);
+        if(isNullOrUndefined(rgb) || rgb === -1){
+            this.log.error(`${this.device.name}: Received Comm Failure for get Saturation`);
+            throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
         }
+
+        // Preform a read, modify, write of RGB with Hue
+        let [r, g, b] = hexToRgb(rgb as string);
+        const [h, s, v] = rgbToHsv(r, g, b);
+        [r, g, b] = hsvToRgb(value as number, s, v);
+        const hexRgb = rgbToHex(r, g, b);
+
+        this.log.info(
+            `${this.device.name}: Received ${value} from Homekit Hue, sending ${hexRgb} from ${rgb} to Hubspace Color RGB`);
+
+        this.deviceService.setValue(this.device.deviceId, DeviceFunction.LightColor, hexRgb);
     }
 
     private async getSaturation(): Promise<CharacteristicValue>{
@@ -189,7 +191,8 @@ export class LightAccessory extends HubspaceAccessory{
 
         const [r, g, b] = hexToRgb(rgb as string);
         const [h, s, v] = rgbToHsv(r, g, b);
-        this.log.info(`${this.device.name}: Received ${rgb} from Hubspace Color RGB, sending ${s} to Homebridge for Saturation`);
+        this.log.info(
+            `${this.device.name}: Received ${rgb} from Hubspace Color RGB, sending ${s} to Homebridge for Saturation`);
 
         // Otherwise return the value
         return (s as CharacteristicValue)!;
@@ -200,20 +203,22 @@ export class LightAccessory extends HubspaceAccessory{
 
         const rgb = await this.deviceService.getValue(this.device.deviceId, DeviceFunction.LightColor);
 
-        // TODO: understand what undefined would look like for this??
         // If the value is not defined then show 'Not Responding'
-        // if(isNullOrUndefined(rgb) || rgb === -1)
-        {
-            // Preform a read, modify, write of RGB with Saturation
-            let [r, g, b] = hexToRgb(rgb as string);
-            const [h, s, v] = rgbToHsv(r, g, b);
-            [r, g, b] = hsvToRgb(h, value as number, v);
-            const hexRgb = rgbToHex(r, g, b);
-
-            this.log.info(`${this.device.name}: Received ${value} from Homekit Saturation, sending ${hexRgb} from ${rgb} to Hubspace Color RGB`);
-
-            // this.deviceService.setValue(this.device.deviceId, DeviceFunction.LightColor, hexRgb);
+        if(isNullOrUndefined(rgb) || rgb === -1){
+            this.log.error(`${this.device.name}: Received Comm Failure for get Saturation`);
+            throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
         }
+
+        // Preform a read, modify, write of RGB with Saturation
+        let [r, g, b] = hexToRgb(rgb as string);
+        const [h, s, v] = rgbToHsv(r, g, b);
+        [r, g, b] = hsvToRgb(h, value as number, v);
+        const hexRgb = rgbToHex(r, g, b);
+
+        this.log.info(
+            `${this.device.name}: Received ${value} from Homekit Saturation, sending ${hexRgb} from ${rgb} to Hubspace Color RGB`);
+
+        // this.deviceService.setValue(this.device.deviceId, DeviceFunction.LightColor, hexRgb);
     }
 
     private setColorMode(): void{

--- a/src/accessories/light-accessory.ts
+++ b/src/accessories/light-accessory.ts
@@ -120,8 +120,12 @@ export class LightAccessory extends HubspaceAccessory{
             const rgb = await this.deviceService.getValue(this.device.deviceId, DeviceFunction.LightColor);
             this.throwErrorIfNullOrUndefined(rgb, 'Received Comm Failure for get Temperature');
 
-            //return clamp(rgbToMired(hexToRgb(rgb as string)), 140, 500);
-            return 140;
+            const mired = clamp(rgbToMired(hexToRgb(rgb as string)), 140, 500);
+            this.log.debug(
+                `${this.device.name}: Received ${rgb} from Hubspace Color Temperature, sending ${Math.round(mired)} to Homebridge`);
+
+            // Try to give it something reasonable to display
+            return Math.round(mired);
         }
     }
 
@@ -167,7 +171,7 @@ export class LightAccessory extends HubspaceAccessory{
 
 
         const [h, s, v] = rgbToHsv(r, g, b);
-        this.log.debug(`sending ${Math.round(h)} to Homebridge for Hue`);
+        this.log.debug(`${this.device.name}: sending ${Math.round(h)} to Homebridge for Hue`);
 
         // Otherwise return the value
         return (Math.round(h) as CharacteristicValue)!;
@@ -227,7 +231,7 @@ export class LightAccessory extends HubspaceAccessory{
         }
 
         const [h, s, v] = rgbToHsv(r, g, b);
-        this.log.debug(`sending ${Math.round(s)} to Homebridge for Saturation`);
+        this.log.debug(`${this.device.name}: sending ${Math.round(s)} to Homebridge for Saturation`);
 
         // Otherwise return the value
         return (Math.round(s) as CharacteristicValue)!;

--- a/src/accessories/light-accessory.ts
+++ b/src/accessories/light-accessory.ts
@@ -188,7 +188,8 @@ export class LightAccessory extends HubspaceAccessory{
 
             this.deviceService.setValue(this.device.deviceId, DeviceFunction.LightColor, hexRgb);
         } else {
-            this.log.error(`${this.device.name}: Received ${value} from Homekit Hue, but cannot send without a Saturation value`);
+            this.hue = value;
+            this.log.warn(`${this.device.name}: Received another ${value} from Homekit Hue, but cannot send without a Saturation value`);
         }
 
     }
@@ -238,7 +239,8 @@ export class LightAccessory extends HubspaceAccessory{
 
             this.deviceService.setValue(this.device.deviceId, DeviceFunction.LightColor, hexRgb);
         } else {
-            this.log.error(`${this.device.name}: Received ${value} from Homekit Saturation, but cannot send without a Hue value`);
+            this.saturation = value;
+            this.log.warn(`${this.device.name}: Received another ${value} from Homekit Saturation, but cannot send without a Hue value`);
         }
     }
 

--- a/src/accessories/light-accessory.ts
+++ b/src/accessories/light-accessory.ts
@@ -167,10 +167,10 @@ export class LightAccessory extends HubspaceAccessory{
 
 
         const [h, s, v] = rgbToHsv(r, g, b);
-        this.log.debug(`sending ${h} to Homebridge for Hue`);
+        this.log.debug(`sending ${Math.round(h)} to Homebridge for Hue`);
 
         // Otherwise return the value
-        return (h as CharacteristicValue)!;
+        return (Math.round(h) as CharacteristicValue)!;
     }
 
     private async setHue(value: CharacteristicValue): Promise<void>{
@@ -227,10 +227,10 @@ export class LightAccessory extends HubspaceAccessory{
         }
 
         const [h, s, v] = rgbToHsv(r, g, b);
-        this.log.debug(`sending ${s} to Homebridge for Saturation`);
+        this.log.debug(`sending ${Math.round(s)} to Homebridge for Saturation`);
 
         // Otherwise return the value
-        return (s as CharacteristicValue)!;
+        return (Math.round(s) as CharacteristicValue)!;
     }
 
     private async setSaturation(value: CharacteristicValue): Promise<void>{

--- a/src/accessories/light-accessory.ts
+++ b/src/accessories/light-accessory.ts
@@ -98,9 +98,15 @@ export class LightAccessory extends HubspaceAccessory{
     }
 
     private async setBrightness(value: CharacteristicValue): Promise<void>{
-        this.log.debug(`${this.device.name}: Received ${value} from Homekit Brightness`);
-        const func = getDeviceFunctionDef(this.device.functions, DeviceFunction.Brightness);
-        await this.deviceService.setValue(this.device.deviceId, func.values[0].deviceValues[0].key, value);
+        // Homekit can send a 0 value for brightness when sliding to off, which is not valid for Hubspace
+        if (value === 0) {
+            // TODO: should be call power off?
+            this.log.debug(`${this.device.name}: Received 0 from Homekit Brightness, ignoring as 0 is not valid for Hubspace`);
+        } else {
+            this.log.debug(`${this.device.name}: Received ${value} from Homekit Brightness`);
+            const func = getDeviceFunctionDef(this.device.functions, DeviceFunction.Brightness);
+            await this.deviceService.setValue(this.device.deviceId, func.values[0].deviceValues[0].key, value);
+        }
     }
 
     private async getTemperature(): Promise<CharacteristicValue>{

--- a/src/accessories/light-accessory.ts
+++ b/src/accessories/light-accessory.ts
@@ -65,7 +65,7 @@ export class LightAccessory extends HubspaceAccessory{
 
     private async getOn(): Promise<CharacteristicValue>{
         // Try to get the value
-        const func = getDeviceFunctionDef(this.device.functions, DeviceFunction.LightPower);
+        const func = getDeviceFunctionDef(this.device.functions, DeviceFunction.Power);
         const value = await this.deviceService.getValueAsBoolean(this.device.deviceId, func.values[0].deviceValues[0].key);
 
         // If the value is not defined then show 'Not Responding'
@@ -81,7 +81,7 @@ export class LightAccessory extends HubspaceAccessory{
 
     private async setOn(value: CharacteristicValue): Promise<void>{
         this.log.debug(`${this.device.name}: Received ${value} from Homekit Power`);
-        const func = getDeviceFunctionDef(this.device.functions, DeviceFunction.LightPower);
+        const func = getDeviceFunctionDef(this.device.functions, DeviceFunction.Power);
         await this.deviceService.setValue(this.device.deviceId, func.values[0].deviceValues[0].key, value);
     }
 

--- a/src/accessories/outlet-accessory.ts
+++ b/src/accessories/outlet-accessory.ts
@@ -1,5 +1,5 @@
 import { CharacteristicValue, PlatformAccessory } from 'homebridge';
-import { DeviceFunction } from '../models/device-functions';
+import { DeviceFunction, getDeviceFunctionDef } from '../models/device-functions';
 import { HubspacePlatform } from '../platform';
 import { isNullOrUndefined } from '../utils';
 import { HubspaceAccessory } from './hubspace-accessory';
@@ -27,7 +27,8 @@ export class OutletAccessory extends HubspaceAccessory{
 
     private async getOn(): Promise<CharacteristicValue>{
         // Try to get the value
-        const value = await this.deviceService.getValueAsBoolean(this.device.deviceId, DeviceFunction.OutletPower);
+        const func = getDeviceFunctionDef(this.device.functions, DeviceFunction.OutletPower);
+        const value = await this.deviceService.getValueAsBoolean(this.device.deviceId, func.values[0].deviceValues[0].key);
 
         // If the value is not defined then show 'Not Responding'
         if(isNullOrUndefined(value)){
@@ -39,7 +40,8 @@ export class OutletAccessory extends HubspaceAccessory{
     }
 
     private async setOn(value: CharacteristicValue): Promise<void>{
-        await this.deviceService.setValue(this.device.deviceId, DeviceFunction.OutletPower, value);
+        const func = getDeviceFunctionDef(this.device.functions, DeviceFunction.OutletPower);
+        await this.deviceService.setValue(this.device.deviceId, func.values[0].deviceValues[0].key, value);
     }
 
 }

--- a/src/models/device-function-def.ts
+++ b/src/models/device-function-def.ts
@@ -1,5 +1,11 @@
 import { DeviceFunction } from './device-functions';
 
+export interface RangeDef{
+    min: number;
+    max: number;
+    step: number;
+}
+
 /**
  * Device function definition
  */
@@ -15,4 +21,7 @@ export interface DeviceFunctionDef{
 
     /** Device function class */
     functionClass: string;
+
+    /** Range */
+    range?: RangeDef;
 }

--- a/src/models/device-function-def.ts
+++ b/src/models/device-function-def.ts
@@ -1,27 +1,12 @@
 import { DeviceFunction } from './device-functions';
 
-export interface RangeDef{
-    min: number;
-    max: number;
-    step: number;
-}
-
 /**
  * Device function definition
  */
 export interface DeviceFunctionDef{
-    /** Type of device this applies to */
-    type: DeviceFunction;
-
-    /** API attribute ID */
-    attributeId: number;
-
     /** API function instance name string */
     functionInstanceName?: string;
 
     /** Device function class */
     functionClass: string;
-
-    /** Range */
-    range?: RangeDef;
 }

--- a/src/models/device-function-def.ts
+++ b/src/models/device-function-def.ts
@@ -1,4 +1,3 @@
-import { DeviceFunction } from './device-functions';
 
 /**
  * Device function definition

--- a/src/models/device-functions.ts
+++ b/src/models/device-functions.ts
@@ -1,17 +1,18 @@
 import { DeviceFunctionDef } from './device-function-def';
+import { DeviceFunctionResponse } from '../responses/device-function-response';
 
 /**
  * Device functions types
  */
 export enum DeviceFunction{
-    LightPower,
-    Brightness,
-    FanPower,
-    FanSpeed,
-    OutletPower,
-    LightTemperature,
-    LightColor,
-    ColorMode
+    LightPower = 'power',
+    Brightness = 'brightness',
+    FanPower = 'fan-power',
+    FanSpeed = 'fan-speed',
+    OutletPower = 'power',
+    LightTemperature = 'color-temperature',
+    LightColor = 'color-rgb',
+    ColorMode = 'color-mode'
 }
 
 /**
@@ -19,68 +20,34 @@ export enum DeviceFunction{
  * with identifiers for discovery and/or manipulation.
  */
 export const DeviceFunctions: DeviceFunctionDef[] = [
-    // {
-    //     type: DeviceFunction.LightPower,
-    //     attributeId: 2,
-    //     functionClass: 'power',
-    //     functionInstanceName: 'light-power'
-    // },
-    // {
-    //     type: DeviceFunction.Brightness,
-    //     attributeId: 4,
-    //     functionClass: 'brightness'
-    // },
     {
-        type: DeviceFunction.FanPower,
-        attributeId: 3,
-        functionClass: 'power',
-        functionInstanceName: 'fan-power'
+        functionClass: DeviceFunction.LightPower,
+        functionInstanceName: DeviceFunction.FanPower
     },
     {
-        type: DeviceFunction.FanSpeed,
-        attributeId: 6,
-        functionClass: 'fan-speed',
-        functionInstanceName: 'fan-speed'
-    },
-    // TODO: handle fan light and bulb light power
-    {
-        type: DeviceFunction.LightPower,
-        attributeId: 1,
-        functionClass: 'power'
+        functionClass: DeviceFunction.FanSpeed,
+        functionInstanceName: DeviceFunction.FanSpeed
     },
     {
-        type: DeviceFunction.Brightness,
-        attributeId: 2,
-        functionClass: 'brightness'
+        functionClass: DeviceFunction.LightPower
     },
     {
-        type: DeviceFunction.LightTemperature,
-        attributeId: 3,
-        functionClass: 'color-temperature'
+        functionClass: DeviceFunction.Brightness
     },
     {
-        type: DeviceFunction.FanSpeed,
-        attributeId: 6,
-        functionClass: 'fan-speed',
-        functionInstanceName: 'fan-speed'
+        functionClass: DeviceFunction.OutletPower
     },
     {
-        type: DeviceFunction.OutletPower,
-        attributeId: 2,
-        functionClass: 'power'
+        functionClass: DeviceFunction.LightTemperature
     },
     {
-        type: DeviceFunction.LightColor,
-        attributeId: 4,
-        functionClass: 'color-rgb'
+        functionClass: DeviceFunction.LightColor
     },
     // This is to switch between Temperature (val:0) and Color (val:1) Light Modes, as Homekit sees these as mutually
     // exclusive, the value should always be Color (val:1) when being controlled by Homekit, otherwise 'undefined' will
     // be returned when reading the current color setting
     {
-        type: DeviceFunction.ColorMode,
-        attributeId: 5,
-        functionClass: 'color-mode'
+        functionClass: DeviceFunction.ColorMode
     }
 ];
 
@@ -90,8 +57,10 @@ export const DeviceFunctions: DeviceFunctionDef[] = [
  * @returns Function definition for type
  * @throws {@link Error} when a type has no definition associated with it
  */
-export function getDeviceFunctionDef(deviceFunction: DeviceFunction): DeviceFunctionDef{
-    const fc = DeviceFunctions.find(fc => fc.type === deviceFunction);
+export function getDeviceFunctionDef(
+    deviceFunctionResponse: DeviceFunctionResponse[], deviceFunction: DeviceFunction): DeviceFunctionResponse{
+
+    const fc = deviceFunctionResponse.find(fc => fc.functionClass === deviceFunction);
 
     // Throw an error when not found - function definition must be set during development,
     // otherwise the plugin will not work as expected.

--- a/src/models/device-functions.ts
+++ b/src/models/device-functions.ts
@@ -10,7 +10,8 @@ export enum DeviceFunction{
     FanSpeed,
     OutletPower,
     LightTemperature,
-    LightColor
+    LightColor,
+    ColorMode
 }
 
 /**
@@ -72,6 +73,14 @@ export const DeviceFunctions: DeviceFunctionDef[] = [
         type: DeviceFunction.LightColor,
         attributeId: 4,
         functionClass: 'color-rgb'
+    },
+    // This is to switch between Temperature (val:0) and Color (val:1) Light Modes, as Homekit sees these as mutually
+    // exclusive, the value should always be Color (val:1) when being controlled by Homekit, otherwise 'undefined' will
+    // be returned when reading the current color setting
+    {
+        type: DeviceFunction.ColorMode,
+        attributeId: 5,
+        functionClass: 'color-mode'
     }
 ];
 

--- a/src/models/device-functions.ts
+++ b/src/models/device-functions.ts
@@ -9,6 +9,8 @@ export enum DeviceFunction{
     FanPower,
     FanSpeed,
     OutletPower,
+    LightTemperature,
+    LightColor
 }
 
 /**
@@ -16,17 +18,17 @@ export enum DeviceFunction{
  * with identifiers for discovery and/or manipulation.
  */
 export const DeviceFunctions: DeviceFunctionDef[] = [
-    {
-        type: DeviceFunction.LightPower,
-        attributeId: 2,
-        functionClass: 'power',
-        functionInstanceName: 'light-power'
-    },
-    {
-        type: DeviceFunction.Brightness,
-        attributeId: 4,
-        functionClass: 'brightness'
-    },
+    // {
+    //     type: DeviceFunction.LightPower,
+    //     attributeId: 2,
+    //     functionClass: 'power',
+    //     functionInstanceName: 'light-power'
+    // },
+    // {
+    //     type: DeviceFunction.Brightness,
+    //     attributeId: 4,
+    //     functionClass: 'brightness'
+    // },
     {
         type: DeviceFunction.FanPower,
         attributeId: 3,
@@ -39,10 +41,37 @@ export const DeviceFunctions: DeviceFunctionDef[] = [
         functionClass: 'fan-speed',
         functionInstanceName: 'fan-speed'
     },
+    // TODO: handle fan light and bulb light power
+    {
+        type: DeviceFunction.LightPower,
+        attributeId: 1,
+        functionClass: 'power'
+    },
+    {
+        type: DeviceFunction.Brightness,
+        attributeId: 2,
+        functionClass: 'brightness'
+    },
+    {
+        type: DeviceFunction.LightTemperature,
+        attributeId: 3,
+        functionClass: 'color-temperature'
+    },
+    {
+        type: DeviceFunction.FanSpeed,
+        attributeId: 6,
+        functionClass: 'fan-speed',
+        functionInstanceName: 'fan-speed'
+    },
     {
         type: DeviceFunction.OutletPower,
         attributeId: 2,
         functionClass: 'power'
+    },
+    {
+        type: DeviceFunction.LightColor,
+        attributeId: 4,
+        functionClass: 'color-rgb'
     }
 ];
 

--- a/src/models/device-functions.ts
+++ b/src/models/device-functions.ts
@@ -5,8 +5,9 @@ import { DeviceFunctionResponse } from '../responses/device-function-response';
  * Device functions types
  */
 export enum DeviceFunction{
-    LightPower = 'power',
+    Power = 'power',
     Brightness = 'brightness',
+    FanLightPower = 'light-power',
     FanPower = 'fan-power',
     FanSpeed = 'fan-speed',
     OutletPower = 'power',
@@ -21,7 +22,11 @@ export enum DeviceFunction{
  */
 export const DeviceFunctions: DeviceFunctionDef[] = [
     {
-        functionClass: DeviceFunction.LightPower,
+        functionClass: DeviceFunction.Power,
+        functionInstanceName: DeviceFunction.FanLightPower
+    },
+    {
+        functionClass: DeviceFunction.Power,
         functionInstanceName: DeviceFunction.FanPower
     },
     {
@@ -29,7 +34,7 @@ export const DeviceFunctions: DeviceFunctionDef[] = [
         functionInstanceName: DeviceFunction.FanSpeed
     },
     {
-        functionClass: DeviceFunction.LightPower
+        functionClass: DeviceFunction.Power
     },
     {
         functionClass: DeviceFunction.Brightness

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -1,4 +1,4 @@
-import { DeviceFunction } from './device-functions';
+import { DeviceFunctionResponse } from '../responses/device-function-response';
 import { DeviceType } from './device-type';
 
 /**
@@ -20,5 +20,5 @@ export interface Device{
     /** Device model */
     model: string[];
     /** Supported device functions */
-    functions: DeviceFunction[];
+    functions: DeviceFunctionResponse[];
 }

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -5,6 +5,8 @@ import { DeviceType } from './device-type';
  * Device definition
  */
 export interface Device{
+    /** Unique UUID within Hubspace */
+    id: string;
     /** Unique UUID within HomeKit */
     uuid: string;
     /** Hubspace device ID */

--- a/src/responses/device-function-response.ts
+++ b/src/responses/device-function-response.ts
@@ -1,9 +1,37 @@
 /**
  * Response for device function
  */
+
+export interface DeviceValues{
+    /** Device values */
+    type: string;
+    /** key id */
+    key: string;
+}
+
+export interface ValuesRange{
+    /** miniumum value */
+    min: number;
+    /** maximum value */
+    max: number;
+    /** step value */
+    step: number;
+}
+
+export interface DeviceFunctionValues{
+    /** Name of the value */
+    name: string;
+    /** Possible values */
+    deviceValues: DeviceValues[];
+    /** Range of Values */
+    range: ValuesRange;
+}
+
 export interface DeviceFunctionResponse{
     /** Class of the function */
     functionClass: string;
     /** Instance name of the function */
     functionInstance: string;
+    /** Function values */
+    values: DeviceFunctionValues[];
 }

--- a/src/services/device.service.ts
+++ b/src/services/device.service.ts
@@ -4,7 +4,7 @@ import { createHttpClientWithBearerInterceptor } from '../api/http-client-factor
 import { AxiosError, AxiosResponse } from 'axios';
 import { DeviceStatusResponse } from '../responses/device-status-response';
 import { CharacteristicValue } from 'homebridge';
-import { convertNumberToHex } from '../utils';
+import { convertNumberToHexReverse } from '../utils';
 import { isAferoError } from '../responses/afero-error-response';
 import { DeviceFunction, getDeviceFunctionDef } from '../models/device-functions';
 
@@ -115,7 +115,7 @@ export class DeviceService{
         }
 
         if(typeof value === 'number'){
-            return convertNumberToHex(value);
+            return convertNumberToHexReverse(value);
         }
 
         throw new Error('The value type is not supported.');

--- a/src/services/device.service.ts
+++ b/src/services/device.service.ts
@@ -26,14 +26,13 @@ export class DeviceService{
      * @param deviceFunction Function to set value for
      * @param value Value to set to attribute
      */
-    async setValue(deviceId: string, deviceFunction: DeviceFunction, value: CharacteristicValue): Promise<void>{
-        const functionDef = getDeviceFunctionDef(deviceFunction);
+    async setValue(deviceId: string, attributeId: string, value: CharacteristicValue): Promise<void>{
         let response: AxiosResponse;
 
         try{
             response = await this._httpClient.post(`accounts/${this._platform.accountService.accountId}/devices/${deviceId}/actions`, {
                 type: 'attribute_write',
-                attrId: functionDef.attributeId,
+                attrId: attributeId,
                 data: this.getDataValue(value)
             });
         }catch(ex){
@@ -53,8 +52,7 @@ export class DeviceService{
      * @param deviceFunction Function to get value for
      * @returns Data value
      */
-    async getValue(deviceId: string, deviceFunction: DeviceFunction): Promise<CharacteristicValue | undefined>{
-        const functionDef = getDeviceFunctionDef(deviceFunction);
+    async getValue(deviceId: string, attributeId: string): Promise<CharacteristicValue | undefined>{
         let deviceStatus: DeviceStatusResponse;
 
         try{
@@ -68,10 +66,10 @@ export class DeviceService{
             return undefined;
         }
 
-        const attributeResponse = deviceStatus.attributes.find(a => a.id === functionDef.attributeId);
+        const attributeResponse = deviceStatus.attributes.find(a => a.id.toString() === attributeId);
 
         if(!attributeResponse){
-            this._platform.log.error(`Failed to find value for ${functionDef.functionInstanceName} for device (device ID: ${deviceId})`);
+            this._platform.log.error(`Failed to find value for ${attributeId} for device (device ID: ${deviceId})`);
             return undefined;
         }
 
@@ -84,8 +82,8 @@ export class DeviceService{
      * @param deviceFunction Function to get value for
      * @returns Boolean value
      */
-    async getValueAsBoolean(deviceId: string, deviceFunction: DeviceFunction): Promise<boolean | undefined>{
-        const value = await this.getValue(deviceId, deviceFunction);
+    async getValueAsBoolean(deviceId: string, attributeId: string): Promise<boolean | undefined>{
+        const value = await this.getValue(deviceId, attributeId);
 
         if(!value) return undefined;
 
@@ -98,8 +96,8 @@ export class DeviceService{
      * @param deviceFunction Function to get value for
      * @returns Integer value
      */
-    async getValueAsInteger(deviceId: string, deviceFunction: DeviceFunction): Promise<number | undefined>{
-        const value = await this.getValue(deviceId, deviceFunction);
+    async getValueAsInteger(deviceId: string, attributeId): Promise<number | undefined>{
+        const value = await this.getValue(deviceId, attributeId);
 
         if(!value || typeof value !== 'string') return undefined;
 

--- a/src/services/device.service.ts
+++ b/src/services/device.service.ts
@@ -110,6 +110,10 @@ export class DeviceService{
 
     private getDataValue(value: CharacteristicValue): string{
 
+        if(typeof value === 'string'){
+            return value;
+        }
+
         if(typeof value === 'boolean'){
             return value ? '01' : '00';
         }

--- a/src/services/discovery.service.ts
+++ b/src/services/discovery.service.ts
@@ -71,7 +71,7 @@ export class DiscoveryService{
                 temperature_device.id.slice(0, -1) + newChar;
                 temperature_device.uuid = this._platform.api.hap.uuid.generate(temperature_device.uuid.slice(0, -1) + newChar);
 
-                const existingTempAccessory = this._cachedAccessories.find(
+                let existingTempAccessory = this._cachedAccessories.find(
                     accessory => (accessory.UUID === temperature_device.uuid && accessory.displayName === temperature_device.name));
                 if (existingTempAccessory) {
                     // the accessory already exists
@@ -80,9 +80,9 @@ export class DiscoveryService{
                 } else {
                     // the accessory does not yet exist, so we need to create it
                     this._platform.log.info('Adding new accessory:', temperature_device.name);
-                    existingAccessory = this.registerNewAccessory(temperature_device);
+                    existingTempAccessory = this.registerNewAccessory(temperature_device);
                 }
-                createAccessoryForDevice(temperature_device, this._platform, existingAccessory);
+                createAccessoryForDevice(temperature_device, this._platform, existingTempAccessory);
 
                 temperature_devices.push(temperature_device);
             }

--- a/src/services/discovery.service.ts
+++ b/src/services/discovery.service.ts
@@ -60,7 +60,7 @@ export class DiscoveryService{
             createAccessoryForDevice(device, this._platform, existingAccessory);
 
             // Special Case for RGB Lightbulbs which will create a second "virutal" lightbulb which is only in the Temperature Color Space
-            if (this._platform.config.dualColorSpace && device.functions.some(fc => fc === DeviceFunction.LightColor)) {
+            if (this._platform.config.dualColorSpace && device.functions.some(fc => fc.functionClass === DeviceFunction.LightColor)) {
                 // Create duplicate device that will only support Temperature Color Space
                 const temperature_device = {...device}; // make a copy
                 temperature_device.name += ' Temperature';
@@ -150,18 +150,17 @@ export class DiscoveryService{
             type: type,
             manufacturer: response.description.device.manufacturerName,
             model: response.description.device.model.split(',').map(m => m.trim()),
-            functions: this.getFunctionsFromResponse(response.description.functions)
+            functions: this.getSupportedFunctionsFromResponse(response.description.functions)
         };
     }
 
-    private getFunctionsFromResponse(supportedFunctions: DeviceFunctionResponse[]): DeviceFunction[]{
-        const output: DeviceFunction[] = [];
+    private getSupportedFunctionsFromResponse(supportedFunctions: DeviceFunctionResponse[]): DeviceFunctionResponse[]{
+        const output: DeviceFunctionResponse[] = [];
 
-        for(const fc of supportedFunctions){
-            // Get the type for the function
-            const type = DeviceFunctions
-                .find(df => df.functionInstanceName === fc.functionInstance && df.functionClass === fc.functionClass)
-                ?.type;
+        for(const df of DeviceFunctions){
+            // Collected only supported Device Functions
+            const type = supportedFunctions
+                .find(fc => df.functionInstanceName === fc.functionInstance && df.functionClass === fc.functionClass);
 
             if(type === undefined || output.indexOf(type) >= 0) continue;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,9 +10,23 @@ export function isNullOrUndefined(...values: unknown[]): boolean{
 /**
  * Converts a decimal number to hexadecimal
  * @param number Number to convert to hexadecimal
+ * @returns string Number in Hexadecimal format in byte order
  */
-export function convertNumberToHex(value: number): string{
+export function convertNumberToHexReverse(value: number): string{
     const hexValue = value.toString(16);
+    const paddedHexValue = hexValue.length % 2 ? '0' + hexValue : hexValue;
+    // split the string into pairs of characters, and reverse the order
+    const bytes = paddedHexValue.match(/.{2}/g)!.reverse();
+    // join the pairs of characters back into a single string
+    return bytes.join('');
+}
 
-    return hexValue.length % 2 ? '0' + hexValue : hexValue;
+/**
+ * Converts a decimal number to
+ * @param originalValue Number to convert to hexadecimal
+ */
+export function normalizeValue(originalValue: number, minValue: number, maxValue: number, newMin: number,
+    newMax: number, step: number): number {
+    const normalizedValue = (originalValue - minValue) * (newMax - newMin) / (maxValue - minValue) + newMin;
+    return Math.round(normalizedValue/step) * step;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,17 +135,28 @@ export function rgbToHsv(r: number, g: number, b: number): [number, number, numb
 }
 
 export function rgbToMired(rgb: [number, number, number]): number {
-    // Convert RGB color to CIE 1931 XYZ color space
-    const xyz = ColorConverter.rgb.xyz(rgb);
+    const r = rgb[0];
+    const g = rgb[1];
+    const b = rgb[2];
 
-    // Convert CIE 1931 XYZ color to CIE 1931 (x, y) chromaticity coordinates
-    const [x, y] = ColorConverter.xyz.xy(xyz);
+    // Normalize RGB values
+    const rNorm = r / 255;
+    const gNorm = g / 255;
+    const bNorm = b / 255;
 
-    // Convert (x, y) chromaticity coordinates to Mired
-    const colorTemperature = 1 / ((0.23881 * x) + (0.25499 * y) - 0.58291);
-    const mired = Math.round(1000000 / colorTemperature);
+    // Calculate the chromaticity coordinates
+    const x = 0.4124 * rNorm + 0.3576 * gNorm + 0.1805 * bNorm;
+    const y = 0.2126 * rNorm + 0.7152 * gNorm + 0.0722 * bNorm;
+    const z = 0.0193 * rNorm + 0.1192 * gNorm + 0.9505 * bNorm;
 
-    return mired;
+    // Calculate the color temperature using the McCamy formula
+    const n = (x - 0.332) / (0.1858 - y);
+    const colorTemperature = (437 * Math.pow(n, 3)) + (3601 * Math.pow(n, 2)) + (6831 * n) + 5517;
+
+    // Convert color temperature to mireds
+    const mireds = 1000000 / colorTemperature;
+
+    return mireds;
 }
 
 export function kelvinToRgb(kelvin: number): [number, number, number] {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { ColorConverter } from 'color-convert';
+
 /**
  * Checks whether at least one value is null or undefined
  * @param values Values to check
@@ -130,4 +132,40 @@ export function rgbToHsv(r: number, g: number, b: number): [number, number, numb
     }
 
     return [h, s, v * 100];
+}
+
+export function rgbToMired(rgb: [number, number, number]): number {
+    // Convert RGB color to CIE 1931 XYZ color space
+    const xyz = ColorConverter.rgb.xyz(rgb);
+
+    // Convert CIE 1931 XYZ color to CIE 1931 (x, y) chromaticity coordinates
+    const [x, y] = ColorConverter.xyz.xy(xyz);
+
+    // Convert (x, y) chromaticity coordinates to Mired
+    const colorTemperature = 1 / ((0.23881 * x) + (0.25499 * y) - 0.58291);
+    const mired = Math.round(1000000 / colorTemperature);
+
+    return mired;
+}
+
+export function kelvinToRgb(kelvin: number): [number, number, number] {
+    const temperature = kelvin / 100;
+
+    let red, green, blue;
+
+    if (temperature <= 66) {
+        red = 255;
+        green = 99.4708025861 * Math.log(temperature) - 161.1195681661;
+        blue = temperature <= 19 ? 0 : 138.5177312231 * Math.log(temperature - 10) - 305.0447927307;
+    } else {
+        red = 329.698727446 * Math.pow(temperature - 60, -0.1332047592);
+        green = 288.1221695283 * Math.pow(temperature - 60, -0.0755148492);
+        blue = 255;
+    }
+
+    return [clamp(red, 0, 255), clamp(green, 0, 255), clamp(blue, 0, 255)];
+}
+
+export function clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,22 @@ export function isNullOrUndefined(...values: unknown[]): boolean{
     return values.some(v => v === undefined || v === null);
 }
 
+export function reverseBytes(value: string): string{
+    const bytes = value.match(/.{2}/g)!.reverse();
+    // join the pairs of characters back into a single string
+    return bytes.join('');
+}
+
+/**
+ * Converts a decimal number to hexadecimal
+ * @param number Number to convert to hexadecimal
+ * @returns string Number in Hexadecimal format in byte order
+ */
+export function convertNumberToHex(value: number): string{
+    const hexValue = value.toString(16);
+    return hexValue.length % 2 ? '0' + hexValue : hexValue;
+}
+
 /**
  * Converts a decimal number to hexadecimal
  * @param number Number to convert to hexadecimal
@@ -15,10 +31,7 @@ export function isNullOrUndefined(...values: unknown[]): boolean{
 export function convertNumberToHexReverse(value: number): string{
     const hexValue = value.toString(16);
     const paddedHexValue = hexValue.length % 2 ? '0' + hexValue : hexValue;
-    // split the string into pairs of characters, and reverse the order
-    const bytes = paddedHexValue.match(/.{2}/g)!.reverse();
-    // join the pairs of characters back into a single string
-    return bytes.join('');
+    return reverseBytes(paddedHexValue);
 }
 
 /**
@@ -29,4 +42,92 @@ export function normalizeValue(originalValue: number, minValue: number, maxValue
     newMax: number, step: number): number {
     const normalizedValue = (originalValue - minValue) * (newMax - newMin) / (maxValue - minValue) + newMin;
     return Math.round(normalizedValue/step) * step;
+}
+
+export function hexToRgb(hex: string): [number, number, number] {
+    // Convert the hex string to a 6-digit integer
+    const hexInt = parseInt(hex, 16);
+
+    // Extract the red, green, and blue components using bit shifting and masking
+    const r = (hexInt >> 16) & 0xFF;
+    const g = (hexInt >> 8) & 0xFF;
+    const b = hexInt & 0xFF;
+
+    // Return the RGB components as an array of numbers
+    return [r, g, b];
+}
+
+export function rgbToHex(r: number, g: number, b: number): string {
+    const hexR = r.toString(16).padStart(2, '0').toUpperCase();
+    const hexG = g.toString(16).padStart(2, '0').toUpperCase();
+    const hexB = b.toString(16).padStart(2, '0').toUpperCase();
+    return hexR + hexG + hexB;
+}
+
+export function hsvToRgb(h: number, s: number, v: number): [number, number, number] {
+    h /= 60;
+    s /= 100;
+    v /= 100;
+
+    const c = v * s;
+    const x = c * (1 - Math.abs((h % 2) - 1));
+    const m = v - c;
+
+    let r = 0;
+    let g = 0;
+    let b = 0;
+
+    if (h >= 0 && h < 1) {
+        r = c;
+        g = x;
+    } else if (h >= 1 && h < 2) {
+        r = x;
+        g = c;
+    } else if (h >= 2 && h < 3) {
+        g = c;
+        b = x;
+    } else if (h >= 3 && h < 4) {
+        g = x;
+        b = c;
+    } else if (h >= 4 && h < 5) {
+        r = x;
+        b = c;
+    } else if (h >= 5 && h < 6) {
+        r = c;
+        b = x;
+    }
+
+    r = Math.round((r + m) * 255);
+    g = Math.round((g + m) * 255);
+    b = Math.round((b + m) * 255);
+
+    return [r, g, b];
+}
+
+export function rgbToHsv(r: number, g: number, b: number): [number, number, number] {
+    r /= 255;
+    g /= 255;
+    b /= 255;
+
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const diff = max - min;
+
+    let h = 0;
+    let s = 0;
+    const v = max;
+
+    if (diff > 0) {
+        s = (diff / max) * 100;
+
+        if (max === r) {
+            h = (60 * ((g - b) / diff) + 360) % 360;
+        } else if (max === g) {
+            h = (60 * ((b - r) / diff) + 120) % 360;
+        } else if (max === b) {
+            h = (60 * ((r - g) / diff) + 240) % 360;
+        }
+    }
+
+    return [h, s, v * 100];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,3 @@
-import { ColorConverter } from 'color-convert';
-
 /**
  * Checks whether at least one value is null or undefined
  * @param values Values to check
@@ -147,7 +145,7 @@ export function rgbToMired(rgb: [number, number, number]): number {
     // Calculate the chromaticity coordinates
     const x = 0.4124 * rNorm + 0.3576 * gNorm + 0.1805 * bNorm;
     const y = 0.2126 * rNorm + 0.7152 * gNorm + 0.0722 * bNorm;
-    const z = 0.0193 * rNorm + 0.1192 * gNorm + 0.9505 * bNorm;
+    // const z = 0.0193 * rNorm + 0.1192 * gNorm + 0.9505 * bNorm;
 
     // Calculate the color temperature using the McCamy formula
     const n = (x - 0.332) / (0.1858 - y);


### PR DESCRIPTION
This adds support for Hubspace Lightbulbs. So far only tested on the BR30 Color CCT Light and A19 Color CCT Light. This also adds a Boolean in the configuration to instance a "second" virtual lightbulb in homekit which will be in the Temperature (Mired/Kelvin) Color Space. It was found that while in the RGB color mode. The whites while in the RGB color mode where not as white as white in the Temperature Color space. When ever the use makes a change to the temperature lightbulb it which change over the temperature color space and then send over the kelvin value.

This also fixes an issue with sending and receiving hex values that are greater than a single byte where the bytes were being sent in reverse order.

This also generalizes the function response to not conflict with the similar fan lights attributeIds which have the same functionClass name such as `brightness`.

TODOs:
- [x] Color Support
- [x] Allow Fan Light / Lightbulb to coexist in `DeviceFunctions`
- [ ] ~~Fix bug with `The device is not available` when there are rapid requests~~ _Will be done in a separate PR_